### PR TITLE
STAMPS-4: cancel identification REST API takes the picture content, not a path

### DIFF
--- a/Prod/SharpNet.csproj
+++ b/Prod/SharpNet.csproj
@@ -36,10 +36,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\..\Temp\Misc.cs" Link="Misc.cs" />
-  </ItemGroup>
-  
-  <ItemGroup>
 		<Reference Include="HDF.PInvoke">
 		  <HintPath>..\Dependencies\HDF.PInvoke.dll</HintPath>
 		  <Private>true</Private>

--- a/SharpNetWebApplication/Controllers/CancelIdentificationController.cs
+++ b/SharpNetWebApplication/Controllers/CancelIdentificationController.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SharpNetWebApplication.Models;
 
@@ -6,10 +8,23 @@ using SharpNetWebApplication.Models;
 
 namespace SharpNetWebApplication.Controllers
 {
+    /// <summary>
+    /// REST API to identify the cancel of a stamp picture.
+    /// The client uploads the content of the picture (not a path) and retrieves the result with the returned id.
+    /// </summary>
+    /// <remarks>
+    /// Not unit tested: this controller is a thin HTTP layer over <see cref="Startup"/> (which loads a trained
+    /// neural network in a static computation thread). The pure id computation is tested behind
+    /// <see cref="CancelIdentificationServices.ComputeId"/>.
+    /// </remarks>
     [Route("[controller]")]
     [ApiController]
     public class CancelIdentificationController : ControllerBase
     {
+        /// <summary>
+        /// Gets the version of the REST API and some usage statistics.
+        /// </summary>
+        /// <returns>A human readable status string.</returns>
         [HttpGet]
         public string Get()
         {
@@ -18,16 +33,36 @@ namespace SharpNetWebApplication.Controllers
             return result;
         }
 
+        /// <summary>
+        /// Gets the cancel identification associated with the provided id (the hash of the picture content,
+        /// as returned by the POST method).
+        /// </summary>
+        /// <param name="id">The id of the cancel identification to retrieve.</param>
+        /// <returns>The cancel identification (its <see cref="CancelIdentification.IsDone"/> flag tells if the prediction is available).</returns>
         [HttpGet("{id}")]
         public CancelIdentification Get(string id)
         {
             return Startup.GetCancelIdentificationIfAvailable(id);
         }
 
+        /// <summary>
+        /// Starts the cancel identification of the provided picture content.
+        /// </summary>
+        /// <param name="picture">The picture to identify, uploaded as a multipart/form-data file.</param>
+        /// <returns>
+        /// The (possibly not yet done) cancel identification: its <see cref="CancelIdentification.Id"/>
+        /// (the hash of the picture content) is to be used to retrieve the result with the GET method.
+        /// </returns>
         [HttpPost]
-        public void Post(string id)
+        public CancelIdentification Post(IFormFile picture)
         {
-            Startup.AddComputation(id);
+            if (picture == null)
+            {
+                return Startup.AddComputation(Array.Empty<byte>());
+            }
+            using var pictureContent = new MemoryStream();
+            picture.CopyTo(pictureContent);
+            return Startup.AddComputation(pictureContent.ToArray());
         }
     }
 }

--- a/SharpNetWebApplication/Models/CancelIdentificationServices.cs
+++ b/SharpNetWebApplication/Models/CancelIdentificationServices.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Security.Cryptography;
+
+namespace SharpNetWebApplication.Models
+{
+    /// <summary>
+    /// Helper methods for the cancel identification REST API.
+    /// </summary>
+    public static class CancelIdentificationServices
+    {
+        /// <summary>
+        /// Computes the unique identifier associated with a picture content.
+        /// Two pictures with the same content always share the same identifier.
+        /// </summary>
+        /// <param name="pictureContent">The raw bytes of the picture.</param>
+        /// <returns>The SHA-256 hash of the content, as a lower case hexadecimal string.</returns>
+        public static string ComputeId(byte[] pictureContent)
+        {
+            using var sha256 = SHA256.Create();
+            var hash = sha256.ComputeHash(pictureContent);
+            return Convert.ToHexString(hash).ToLowerInvariant();
+        }
+    }
+}

--- a/SharpNetWebApplication/Startup.cs
+++ b/SharpNetWebApplication/Startup.cs
@@ -22,7 +22,10 @@ namespace SharpNetWebApplication
         
         #region private fields
         private static Network Network;
+        //temporary files (one per picture content received through the REST API) waiting to be processed
         private static readonly List<string> ToProcess =  new ();
+        //directory where the picture contents received through the REST API are stored while waiting to be processed
+        private static readonly string TempPictureDirectory = InitializeTempPictureDirectory();
         #endregion
         #region public fields
         private static readonly IDictionary<string, CancelIdentification> Cache = new ConcurrentDictionary<string, CancelIdentification>();
@@ -47,18 +50,24 @@ namespace SharpNetWebApplication
                     var predictions = CancelDatabase.PredictCancelsWithProba(Network, picturePaths);
                     for (var index = 0; index < predictions.Count; index++)
                     {
-                        if (!Cache.TryGetValue(picturePaths[index], out var cancelIdentification))
+                        //the temporary picture file is named '<id>.img' (with 'id' the hash of the picture content)
+                        var id = Path.GetFileNameWithoutExtension(picturePaths[index]);
+                        if (!Cache.TryGetValue(id, out var cancelIdentification))
                         {
                             cancelIdentification = new CancelIdentification {StartComputationDate = DateTime.Now};
                         }
-                        cancelIdentification.Id = picturePaths[index];
+                        cancelIdentification.Id = id;
                         cancelIdentification.IsDone = true;
                         cancelIdentification.Prediction = predictions[index].Item1;
                         cancelIdentification.PredictionProbability = predictions[index].Item2;
                         cancelIdentification.ComputationTimeInMilliseconds = (int)(DateTime.Now - cancelIdentification.StartComputationDate).TotalMilliseconds;
                         Program.TotalMilliSecondsForAllRequests += cancelIdentification.ComputationTimeInMilliseconds;
-                        Cache[picturePaths[index]] = cancelIdentification;
+                        Cache[id] = cancelIdentification;
                         Log.Debug("Identification of "+ cancelIdentification .Id+ " : "+ cancelIdentification.Prediction + " (proba:"+Math.Round(100*cancelIdentification.PredictionProbability,1)+"%)");
+                    }
+                    foreach (var picturePath in picturePaths)
+                    {
+                        TryDeleteTempPictureFile(picturePath);
                     }
                 }
                 if (Cache.Count > 1000)
@@ -78,35 +87,85 @@ namespace SharpNetWebApplication
         }
 
 
-        public static CancelIdentification AddComputation(string path)
+        /// <summary>
+        /// Starts the cancel identification of the provided picture content (if it is not already available).
+        /// </summary>
+        /// <param name="pictureContent">The raw bytes of the picture to identify.</param>
+        /// <returns>
+        /// The (possibly not yet done) cancel identification associated with the picture content.
+        /// Its <see cref="CancelIdentification.Id"/> is the hash of the content, to be used to retrieve the result later.
+        /// </returns>
+        /// <remarks>
+        /// Not unit tested: this method relies on the static computation thread (which loads a trained neural network)
+        /// and on disk I/O. The pure id computation is tested behind <see cref="CancelIdentificationServices.ComputeId"/>.
+        /// </remarks>
+        public static CancelIdentification AddComputation(byte[] pictureContent)
         {
-            Log.Debug("AddComputation of "+path);
-
-            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+            if (pictureContent == null || pictureContent.Length == 0)
             {
-                Log.Warn(path+" is invalid or missing");
-                return new CancelIdentification { Id = path, IsDone = true, Prediction = "Invalid path", PredictionProbability = 0.0, StartComputationDate = DateTime.Now, ComputationTimeInMilliseconds = 0};
+                Log.Warn("the provided picture content is empty");
+                return new CancelIdentification { Id = "", IsDone = true, Prediction = "Invalid content", PredictionProbability = 0.0, StartComputationDate = DateTime.Now, ComputationTimeInMilliseconds = 0};
             }
+            var id = CancelIdentificationServices.ComputeId(pictureContent);
+            Log.Debug("AddComputation of picture content with id "+id);
             Interlocked.Increment(ref Program.NbRequest);
-            if (Cache.ContainsKey(path))
+            if (Cache.ContainsKey(id))
             {
-                return Cache[path];
+                return Cache[id];
             }
-            Cache[path] = new CancelIdentification { Id = path, IsDone = false, Prediction = "", PredictionProbability = 0.0, StartComputationDate = DateTime.Now, ComputationTimeInMilliseconds = 0 };
-            Log.Debug("Add "+path+" to the process list");
+            Cache[id] = new CancelIdentification { Id = id, IsDone = false, Prediction = "", PredictionProbability = 0.0, StartComputationDate = DateTime.Now, ComputationTimeInMilliseconds = 0 };
+            var picturePath = Path.Combine(TempPictureDirectory, id + ".img");
+            File.WriteAllBytes(picturePath, pictureContent);
+            Log.Debug("Add "+picturePath+" to the process list");
 
             lock (ToProcess)
             {
-                ToProcess.Add(path);
+                ToProcess.Add(picturePath);
             }
-            return Cache[path];
+            return Cache[id];
         }
 
 
-        public static CancelIdentification GetCancelIdentificationIfAvailable(string path)
+        /// <summary>
+        /// Gets the cancel identification associated with the provided id (the hash of the picture content).
+        /// </summary>
+        /// <param name="id">The id returned by <see cref="AddComputation"/>.</param>
+        /// <returns>
+        /// The cancel identification if the id is known (its <see cref="CancelIdentification.IsDone"/> flag tells
+        /// if the prediction is available), or a 'not done' result for an unknown id.
+        /// </returns>
+        /// <remarks>
+        /// Not unit tested: this method relies on the static cache filled by the computation thread
+        /// (which loads a trained neural network and cannot be exercised deterministically in a unit test).
+        /// </remarks>
+        public static CancelIdentification GetCancelIdentificationIfAvailable(string id)
         {
-            Log.Debug("GetCancelIdentificationIfAvailable of " + path);
-            return Cache.ContainsKey(path) ? Cache[path] : AddComputation(path);
+            Log.Debug("GetCancelIdentificationIfAvailable of " + id);
+            if (Cache.TryGetValue(id, out var cancelIdentification))
+            {
+                return cancelIdentification;
+            }
+            Log.Warn("unknown cancel identification id " + id);
+            return new CancelIdentification { Id = id, IsDone = false, Prediction = "Unknown id", PredictionProbability = 0.0, StartComputationDate = DateTime.Now, ComputationTimeInMilliseconds = 0 };
+        }
+
+        private static string InitializeTempPictureDirectory()
+        {
+            var tempPictureDirectory = Path.Combine(Path.GetTempPath(), "SharpNetWebApplication");
+            Directory.CreateDirectory(tempPictureDirectory);
+            return tempPictureDirectory;
+        }
+
+        private static void TryDeleteTempPictureFile(string picturePath)
+        {
+            try
+            {
+                File.Delete(picturePath);
+            }
+            catch (Exception e)
+            {
+                Log.Warn("Fail to delete the temporary picture file " + picturePath, e);
+            }
         }
 
         static Startup()

--- a/Tests/SharpNetTests.csproj
+++ b/Tests/SharpNetTests.csproj
@@ -23,6 +23,9 @@
     <PackageReference Include="NUnit3TestAdapter" version="3.16.1" />
 	<PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />	
     <ProjectReference Include="..\Prod\SharpNet.csproj" />
+    <Compile Include="..\SharpNetWebApplication\Models\CancelIdentificationServices.cs">
+      <Link>WebApplication\CancelIdentificationServices.cs</Link>
+    </Compile>
 	<PackageReference Include="HDF.PInvoke" Version="1.10.6.1" />
     <PackageReference Include="PhotoSauce.MagicScaler" Version="0.11.1" />
 	<PackageReference Include="CsvHelper" Version="30.0.1" />	

--- a/Tests/WebApplication/TestCancelIdentificationServices.cs
+++ b/Tests/WebApplication/TestCancelIdentificationServices.cs
@@ -1,0 +1,31 @@
+using System.Text;
+using NUnit.Framework;
+using SharpNetWebApplication.Models;
+
+namespace SharpNetTests.WebApplication
+{
+    [TestFixture]
+    public class TestCancelIdentificationServices
+    {
+        [Test]
+        public void TestComputeIdReturnsSha256HexOfContent()
+        {
+            //well known SHA-256 test vector for the ASCII string "abc"
+            var id = CancelIdentificationServices.ComputeId(Encoding.ASCII.GetBytes("abc"));
+            Assert.AreEqual("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", id);
+        }
+
+        [Test]
+        public void TestComputeIdIsDeterministic()
+        {
+            var content = new byte[] { 1, 2, 3, 4, 5 };
+            Assert.AreEqual(CancelIdentificationServices.ComputeId(content), CancelIdentificationServices.ComputeId((byte[])content.Clone()));
+        }
+
+        [Test]
+        public void TestComputeIdChangesWhenContentChanges()
+        {
+            Assert.AreNotEqual(CancelIdentificationServices.ComputeId(new byte[] { 1, 2, 3 }), CancelIdentificationServices.ComputeId(new byte[] { 1, 2, 4 }));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- The `POST /cancelidentification` method now receives the picture bytes as a multipart/form-data upload (`picture` file field) instead of a server-local file path.
- Each picture is identified by the SHA-256 hash of its content (`CancelIdentificationServices.ComputeId`); the uploaded bytes are written to a temp file for the prediction pipeline and deleted once predicted.
- `GET /cancelidentification/{id}` returns the cached result for that id and no longer touches any path; unknown ids get a not-done result instead of triggering a computation.
- Also drops the `Compile` include of `C:\Temp\Misc.cs` (a machine-local file outside the repository) from `Prod/SharpNet.csproj`, which broke the build of any other checkout - same removal as the pending local refactoring commit.

## Tests
- New NUnit fixture `TestCancelIdentificationServices` (3 tests) covering the id computation; linked into `SharpNetTests` as a source file to avoid pulling the ASP.NET Core shared framework into the test host.
- `dotnet build SharpNet.sln`: 0 errors; the 3 new tests pass on this exact tree. The controller/`Startup` plumbing is the untestable I/O edge (static computation thread loading a trained network) and is documented as such in `<remarks>`.

Client-side counterpart: FranckZibi/StampExpert PR (StampExpert uploads the picture content and polls with the returned id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)